### PR TITLE
fix: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ovh/critical-databases
+* @Arnoways @B-Marine @jriouovh @koleo @wilfriedroset


### PR DESCRIPTION
The "ovh/critical-databases" group is private and cannot be used in the CODEOWNERS file. Using an explicit member's list instead.