### PR TITLE
Fix golangci configuration as 'max-per-linter' not allowed

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # Visit https://golangci-lint.run/ for usage documentation
 # and information on other useful linters
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
@@ -25,4 +25,3 @@ linters:
     - unconvert
     - unparam
     - unused
-


### PR DESCRIPTION
This should fix the fail in https://github.com/ovh/terraform-provider-eyaml/pull/80