### PR TITLE
add a data_wo_reference to track value changes

### DIFF
--- a/docs/resources/encrypt.md
+++ b/docs/resources/encrypt.md
@@ -57,5 +57,6 @@ EOT
 
 ### Read-Only
 
+- `data_wo_reference` (String) SHA256 hash of the value passed in `data` or `data_wo`. Can be used to detect changes to the write-only value.
 - `encrypted_data` (String) Encrypted data.
 - `id` (String) ID of the encrypted data.

--- a/internal/provider/resource_encrypt.go
+++ b/internal/provider/resource_encrypt.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -27,12 +29,13 @@ type EncryptedDataResource struct {
 }
 
 type EncryptedDataResourceModel struct {
-	PublicKey     types.String `tfsdk:"public_key"`
-	Data          types.String `tfsdk:"data"`
-	DataWO        types.String `tfsdk:"data_wo"`
-	DataWOVersion types.String `tfsdk:"data_wo_version"`
-	EncryptedData types.String `tfsdk:"encrypted_data"`
-	Id            types.String `tfsdk:"id"`
+	PublicKey       types.String `tfsdk:"public_key"`
+	Data            types.String `tfsdk:"data"`
+	DataWO          types.String `tfsdk:"data_wo"`
+	DataWOVersion   types.String `tfsdk:"data_wo_version"`
+	DataWOReference types.String `tfsdk:"data_wo_reference"`
+	EncryptedData   types.String `tfsdk:"encrypted_data"`
+	Id              types.String `tfsdk:"id"`
 }
 
 func (r *EncryptedDataResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -71,6 +74,10 @@ func (r *EncryptedDataResource) Schema(ctx context.Context, req resource.SchemaR
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
+			},
+			"data_wo_reference": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "SHA256 hash of the value passed in `data` or `data_wo`. Can be used to detect changes to the write-only value.",
 			},
 			"encrypted_data": schema.StringAttribute{
 				Computed:            true,
@@ -115,6 +122,11 @@ func (r *EncryptedDataResource) ValidateConfig(ctx context.Context, req resource
 	}
 }
 
+func dataHash(data string) string {
+	h := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(h[:])
+}
+
 func (r *EncryptedDataResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
@@ -146,6 +158,7 @@ func (r *EncryptedDataResource) Create(ctx context.Context, req resource.CreateR
 	}
 
 	planData.EncryptedData = types.StringValue(fmt.Sprintf("ENC[PKCS7,%s]", encryptedData))
+	planData.DataWOReference = types.StringValue(dataHash(plaintext))
 	planData.Id = types.StringValue(strconv.FormatInt(time.Now().Unix(), 10))
 	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
 }

--- a/internal/provider/resource_encrypt_test.go
+++ b/internal/provider/resource_encrypt_test.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"regexp"
@@ -26,12 +28,14 @@ func TestAccEncryptedDataResource_data(t *testing.T) {
 					testAccEncryptedDataResourceCheckWriteOnlyNotPersisted(),
 					resource.TestCheckNoResourceAttr("eyaml_encrypt.test", "data_wo_version"),
 					testAccEncryptedDataResourceCheckEncryptedValue(privateKey, publicKey, firstExpectedValue),
+					resource.TestCheckResourceAttr("eyaml_encrypt.test", "data_wo_reference", testAccDataHash(firstExpectedValue)),
 				),
 			},
 			{
 				Config: testAccEncryptedDataResourceConfig(publicKey, secondExpectedValue),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccEncryptedDataResourceCheckEncryptedValue(privateKey, publicKey, secondExpectedValue),
+					resource.TestCheckResourceAttr("eyaml_encrypt.test", "data_wo_reference", testAccDataHash(secondExpectedValue)),
 				),
 			},
 		},
@@ -55,6 +59,7 @@ func TestAccEncryptedDataResource_dataWO(t *testing.T) {
 					resource.TestCheckNoResourceAttr("eyaml_encrypt.test", "data"),
 					testAccEncryptedDataResourceCheckWriteOnlyNotPersisted(),
 					testAccEncryptedDataResourceCheckEncryptedValue(privateKey, publicKey, firstExpectedValue),
+					resource.TestCheckResourceAttr("eyaml_encrypt.test", "data_wo_reference", testAccDataHash(firstExpectedValue)),
 				),
 			},
 			{
@@ -68,6 +73,7 @@ func TestAccEncryptedDataResource_dataWO(t *testing.T) {
 					resource.TestCheckNoResourceAttr("eyaml_encrypt.test", "data"),
 					testAccEncryptedDataResourceCheckWriteOnlyNotPersisted(),
 					testAccEncryptedDataResourceCheckEncryptedValue(privateKey, publicKey, secondExpectedValue),
+					resource.TestCheckResourceAttr("eyaml_encrypt.test", "data_wo_reference", testAccDataHash(secondExpectedValue)),
 				),
 			},
 		},
@@ -115,6 +121,11 @@ func testAccEncryptedDataResourceKeys(t *testing.T) (string, string) {
 	}
 
 	return string(publicKeyBytes), string(privateKeyBytes)
+}
+
+func testAccDataHash(data string) string {
+	h := sha256.Sum256([]byte(data))
+	return hex.EncodeToString(h[:])
 }
 
 func testAccEncryptedDataResourceCheckEncryptedValue(privateKey, publicKey, expectedValue string) resource.TestCheckFunc {


### PR DESCRIPTION
Compute a sha256 hash of the data_wo value to be able to track changes and compare if multiple resources are created with the same ephemeral, to ensure they are in sync.